### PR TITLE
Add German translation

### DIFF
--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <string name="appName">Editor</string>
+  
+  <string name="search">Suchen…</string>
+  <string name="open">Datei öffnen…</string>
+  <string name="save">Speichern</string>
+  <string name="openRecent">Zuletzt geöffnet</string>
+  <string name="saveAs">Speichern unter…</string>
+  <string name="wrap">Zeilenumbruch</string>
+  <string name="suggest">Vorschläge</string>
+  <string name="theme">Thema</string>
+  <string name="light">Hell</string>
+  <string name="dark">Dunkel</string>
+  <string name="retro">Retro</string>
+  <string name="size">Schriftgröße</string>
+  <string name="small">Klein</string>
+  <string name="medium">Mittel</string>
+  <string name="large">Groß</string>
+  <string name="typeface">Schriftart</string>
+  <string name="mono">Nichtproportional</string>
+  <string name="normal">Proportional</string>
+  <string name="about">Über</string>
+
+  <string name="version" formatted="false">Editor Version %s\nBuild
+  %s\nCopyright \u00A9 2017 Bill Farmer\nDeutsche Übersetzung von <a
+  href="https://github.com/Markus00000">Markus Weimar</a>\nFranzösische
+  Übersetzung von <a href="https://github.com/milouse">Étienne
+  Deparis</a>\nLizenz <a href="https://www.gnu.org/licenses/gpl.txt">GNU
+  GPLv3</a>
+  </string>
+
+  <string name="choose">Geben Sie einen Dateinamen ein.</string>
+  <string name="loading">Laden…</string>
+
+  <string name="modified">
+    Ihre Änderungen wurden noch nicht gespeichert. Möchten Sie sie verwerfen?
+  </string>
+
+  <string name="changedReload">
+    Die Datei wurde geändert. Möchten Sie sie neu laden?
+  </string>
+
+  <string name="changedOverwrite">
+    Die Datei wurde geändert. Möchten Sie sie überschreiben?
+  </string>
+
+  <string name="ok">OK</string>
+  <string name="reload">Neu laden</string>
+  <string name="overwrite">Überschreiben</string>
+  <string name="discard">Verwerfen</string>
+  <string name="cancel">Abbrechen</string>
+
+</resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -25,9 +25,9 @@
 
   <string name="version" formatted="false">Editor version %s\nBuilt
   %s\nCopyright \u00A9 2017 Bill Farmer\nFrench translation by <a
-  href="https://github.com/milouse">Étienne Deparis</a>\nLicence <a
-  href="https://www.gnu.org/licenses/gpl.txt">GNU GPLv3</a>
-  </string>
+  href="https://github.com/milouse">Étienne Deparis</a>\nGerman translation by
+  <a href="https://github.com/Markus00000">Markus Weimar</a>\nLicence <a
+  href="https://www.gnu.org/licenses/gpl.txt">GNU GPLv3</a> </string>
 
   <string name="choose">Choose a file name</string>
   <string name="loading">Loading…</string>


### PR DESCRIPTION
I didn’t change the about dialog in the French translation. Maybe @milouse can update it to keep them all in sync.

Depending on the number of future translations, it might be easier if they were listed in README.md instead.