### PR TITLE
Fix Save As not updating title

### DIFF
--- a/src/main/java/org/billthefarmer/editor/Editor.java
+++ b/src/main/java/org/billthefarmer/editor/Editor.java
@@ -895,6 +895,11 @@ public class Editor extends Activity
                             File(Environment.getExternalStorageDirectory(),
                                  File.separator + name);
 
+                    // Set interface title
+                    Uri uri = Uri.fromFile(file);
+                    String title = uri.getLastPathSegment();
+                    setTitle(title);
+
                     path = file.getPath();
                     saveFile();
                 }


### PR DESCRIPTION
Previously, if you saved a file using "Save As," the title wouldn't be updated to match the new file location.