### PR TITLE
Don't forget content URI on save

### DIFF
--- a/src/main/java/org/billthefarmer/editor/Editor.java
+++ b/src/main/java/org/billthefarmer/editor/Editor.java
@@ -2320,10 +2320,7 @@ public class Editor extends Activity
                 saveFile(file);
 
             else
-            {
                 saveFile(content);
-                content = null;
-            }
         }
     }
 


### PR DESCRIPTION
When saving a file to the content URI, keep
remembering the content URI, so e.g. saving to
the same file will work again.

Fixes: #186