### PR TITLE
Document maximum large file size #230

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ box at the top.
 
 ### Large files
 Editor loads the whole of file to be edited into memory. It will not
-load large files which would cause performance issues or cause the app
-to crash. Please do not raise issues about the **Too large** dialog
-shown when attempting to load a large file.
+load large files (larger than ~500Kb) which would cause performance
+issues or cause the app to crash. Please do not raise issues about
+the **Too large** dialog shown when attempting to load a large file.
 
 ![Editor](https://github.com/billthefarmer/billthefarmer.github.io/raw/master/images/Editor.png) ![Editor](https://github.com/billthefarmer/billthefarmer.github.io/raw/master/images/Editor-chooser.png)
 


### PR DESCRIPTION
Based on https://github.com/billthefarmer/editor/blob/89876eb516dab5518f59a17280c3b91cbb26cbe9/src/main/java/org/billthefarmer/editor/FileAdapter.java#L52

    TOO_LARGE = 524288